### PR TITLE
Update breakman.yml

### DIFF
--- a/.github/workflows/breakman.yml
+++ b/.github/workflows/breakman.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Customize the ruby version depending on your needs
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
 


### PR DESCRIPTION
Migrate from actions/ to ruby/

```
0s
Run actions/setup-ruby@v[1](https://github.com/octodemo/railsgoat/actions/runs/4106676857/jobs/7085204731#step:3:1)
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.[7](https://github.com/octodemo/railsgoat/actions/runs/4106676857/jobs/7085204731#step:3:8) not found
```